### PR TITLE
Update scheduling link and Jack alias metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,15 +26,25 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href="https://jacksonmaroon.com/" />
-    <title>Jackson Maroon</title>
-    <meta name="description" content="Product Manager with proven track record at Kearney, NIH, and W&L. Expertise in data-driven solutions, user research, and AI. Available for PM roles May 2026." />
-    <meta name="author" content="Jackson Maroon" />
-    <meta name="keywords" content="product manager, AI, data analysis, user research, W&L, Kearney, NIH, product management jobs" />
+    <title>Jackson "Jack" Maroon</title>
+    <meta
+      name="description"
+      content="Jackson (Jack) Maroon is a product manager with a proven track record at Kearney, NIH, and W&L. Expertise in data-driven solutions, user research, and AI. Available for PM roles May 2026."
+    />
+    <meta name="author" content="Jackson (Jack) Maroon" />
+    <meta
+      name="keywords"
+      content="product manager, AI, data analysis, user research, W&L, Kearney, NIH, product management jobs, Jackson Maroon, Jack Maroon"
+    />
+    <meta name="application-name" content="Jackson &quot;Jack&quot; Maroon" />
     <meta name="robots" content="index, follow" />
     <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
 
-    <meta property="og:title" content="Jackson Maroon - Product Manager & AI Enthusiast" />
-    <meta property="og:description" content="Product Manager with proven track record at Kearney, NIH, and W&L. Expertise in data-driven solutions, user research, and AI. Available for PM roles May 2026." />
+    <meta property="og:title" content="Jackson &quot;Jack&quot; Maroon - Product Manager & AI Enthusiast" />
+    <meta
+      property="og:description"
+      content="Jackson (Jack) Maroon is a product manager with a proven track record at Kearney, NIH, and W&L. Expertise in data-driven solutions, user research, and AI. Available for PM roles May 2026."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://jacksonmaroon.com/" />
     <meta property="og:site_name" content="Jackson Maroon" />
@@ -45,8 +55,11 @@
     <meta property="og:image:alt" content="Monochrome Jackson Maroon wordmark on a dark background" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Jackson Maroon - Product Manager" />
-    <meta name="twitter:description" content="Product Manager with expertise in AI, data analysis, and user research. Available for PM roles." />
+    <meta name="twitter:title" content="Jackson &quot;Jack&quot; Maroon - Product Manager" />
+    <meta
+      name="twitter:description"
+      content="Jackson (Jack) Maroon is a product manager with expertise in AI, data analysis, and user research. Available for PM roles."
+    />
     <meta name="twitter:image" content="https://jacksonmaroon.com/opengraph-image.svg" />
     <meta name="twitter:image:alt" content="Monochrome Jackson Maroon wordmark on a dark background" />
 
@@ -55,6 +68,7 @@
         "@context": "https://schema.org",
         "@type": "Person",
         "name": "Jackson Maroon",
+        "alternateName": ["Jack Maroon"],
         "url": "https://jacksonmaroon.com/",
         "image": "https://jacksonmaroon.com/opengraph-image.svg",
         "jobTitle": "Product Manager",

--- a/src/components/SimpleContact.tsx
+++ b/src/components/SimpleContact.tsx
@@ -79,7 +79,7 @@ const SimpleContact = () => {
 
               <div className="space-y-3">
                 <Button className="w-full" asChild>
-                  <a href="mailto:jmaroon@mail.wlu.edu?subject=PM Opportunity Discussion">Schedule a Conversation</a>
+                  <a href="https://cal.com/jackson-maroon">Schedule a Conversation</a>
                 </Button>
                 <Button variant="outline" className="w-full" asChild>
                   <a href="mailto:jmaroon@mail.wlu.edu?subject=Resume Request">Request Full Resume</a>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -18,7 +18,7 @@ const Index = () => {
       <footer className="py-8 px-6 text-center border-t">
         <div className="max-w-4xl mx-auto">
           <p className="text-sm text-muted-foreground">
-            © 2024 Jackson Maroon. Built with passion for product management.
+            © 2025 Jackson Maroon
           </p>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- update the "Schedule a Conversation" button in `SimpleContact` to open the new Cal.com scheduling page
- refresh the footer copyright text to "© 2025 Jackson Maroon"
- add Jack Maroon alias references to the site metadata for better name recognition in search

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c94b93548c8322afceb8f8be87d13c